### PR TITLE
downgrade to java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
         <jackson.version>2.7.4</jackson.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
Jenkins has Oracle JDK 8 and Open JDK 7. Oracle JDK 8 doesn't include Unlimited Strength Encryption, but Open JDK 7 does. We'll need to downgrade to JDK 7 so we can encrypt our uploads.