### PR TITLE
studyIdExcludedInExport flag

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/exporter/integration/ExportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/integration/ExportTest.java
@@ -432,7 +432,7 @@ public class ExportTest {
             String columnValue = appVersionColumnList.get(i);
 
             if (headerName.equals("originalTable")) {
-                assertEquals(columnValue, TEST_STUDY_ID + "-legacy-survey-v1");
+                assertEquals(columnValue, "legacy-survey-v1");
             } else {
                 commonColumnsVerification(headerName, columnValue, recordId, uploadRecord);
             }


### PR DESCRIPTION
See https://github.com/Sage-Bionetworks/Bridge-Exporter/pull/56

Note that this assumes that the API study will always have studyIdExcludedInExport=true