### PR TITLE
Test against new AWS Bridge Exporter env

### DIFF
--- a/src/test/resources/BridgeExporter-test.conf
+++ b/src/test/resources/BridgeExporter-test.conf
@@ -14,9 +14,9 @@ prod.exporter.ddb.prefix = prod-exporter-
 
 # Bridge Exporter Service SQS queues
 local.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-local
-dev.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-dev
-uat.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-uat
-prod.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-prod
+dev.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-mi3sym9mrs-stack-AWSEBWorkerQueue-1W434RXLTTRO1
+uat.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-agmuuqbanv-stack-AWSEBWorkerQueue-QTOVH1V7SHS6
+prod.exporter.request.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-8fm2xp95rm-stack-AWSEBWorkerQueue-1ELXM125D5PL2
 
 local.record.id.override.bucket=org-sagebridge-exporter-recordids-local
 dev.record.id.override.bucket=org-sagebridge-exporter-recordids-develop


### PR DESCRIPTION
The infra for Bridge-Exporter app is now automated with
Bridge-Exporter-infra[1] repo. This new project uses cloudformation
to setup the bridge exporter env and SQS queues. We should switch to
using this environment and deprecate the manually created exporter
environment.

[1] https://github.com/Sage-Bionetworks/Bridge-Exporter-infra